### PR TITLE
feat: implement multi-ron handling in hand recording feature

### DIFF
--- a/EMOJI_REACTIONS.md
+++ b/EMOJI_REACTIONS.md
@@ -1,0 +1,93 @@
+# Live Game Emoji Reactions — Feature Documentation
+
+This document describes a planned feature: allowing spectators on the live game page to add emoji reactions to each hand history item. It is **blocked on user authentication** (not yet implemented). Revisit this doc when auth is available.
+
+---
+
+## Overview
+
+- **Where:** `/game/[id]/live` — spectators viewing a game in progress.
+- **What:** Each hand in the hand history can receive emoji reactions (e.g. 👍 👏 🔥). Spectators see aggregate counts and can add or remove their own reaction.
+- **Stable key for a hand:** `(game_id, hand_seq)` — one “hand” = one round (e.g. East 1, Honba 0), grouped by `hand_seq` in the UI.
+
+---
+
+## Dependency: User Authentication
+
+**Per-user reactions require a notion of “who reacted.”**
+
+- The desired data model stores one row per (game, hand, emoji, **user**).
+- **User auth is not implemented yet.** Until it is, we cannot reliably identify spectators (e.g. no `user_id` or session to attach to reactions).
+- **Action:** Implement user authentication first (e.g. Supabase Auth, anonymous or signed-in). Then use the authenticated user (or anonymous user) id as `user_id` (or `spectator_id`) when recording reactions.
+
+---
+
+## Data Model (Per-User)
+
+**Table: `hand_reactions`**
+
+| Column       | Type        | Notes                                                         |
+| ------------ | ----------- | ------------------------------------------------------------- |
+| `id`         | uuid        | PK, default `gen_random_uuid()`                               |
+| `game_id`    | uuid        | FK → `games(id)`, NOT NULL                                    |
+| `hand_seq`   | int         | NOT NULL, matches `hand_events.hand_seq`                      |
+| `emoji`      | text        | NOT NULL, e.g. `"👍"`, `"🔥"`                                 |
+| `user_id`    | uuid        | FK → auth users (or `users` table when implemented), NOT NULL |
+| `created_at` | timestamptz | default `now()`                                               |
+
+- **Unique constraint:** `(game_id, hand_seq, emoji, user_id)` — one reaction per user per hand per emoji (user can react with multiple different emojis on the same hand).
+- **Indexes:** `(game_id, hand_seq)` for listing reactions for a game’s hand history; optionally `(user_id)` for “my reactions” queries.
+
+**Aggregates for UI:** Count by `(game_id, hand_seq, emoji)` for display; and “did current user react with this emoji?” by joining on `user_id`.
+
+---
+
+## API (Planned)
+
+- **Read reactions (with counts and “mine”)**
+  - Option A: Extend `GET /api/games/[gameId]` to include reactions when the request is authenticated (e.g. `reactionsByHand: Record<hand_seq, { [emoji]: { count: number, mine: boolean } }>`).
+  - Option B: `GET /api/games/[gameId]/reactions` — returns same shape; call when authenticated. Page can poll this alongside or instead of embedding in game payload.
+
+- **Add reaction:** `POST /api/games/[gameId]/hands/[handSeq]/reactions`
+  - Body: `{ emoji: "👍" }`.
+  - Requires auth; server sets `user_id` from session.
+
+- **Remove reaction:** `DELETE /api/games/[gameId]/hands/[handSeq]/reactions?emoji=👍`
+  - Requires auth; deletes row for current user + game + hand_seq + emoji.
+
+- **Rate limiting:** Per user (and optionally per IP) to prevent spam (e.g. max N reactions per minute per game).
+
+---
+
+## UI Integration
+
+- **Scope:** Live page only (`/game/[id]/live`). Hand history comes from `game.handEvents`, rendered by `HandHistory` → `HandHistoryItem` (`apps/web/src/components/features/game-recording/HandHistory.tsx`).
+- **Hand identity in UI:** Each item has `hand.handSeq`; page has `gameId` → key = `(gameId, hand.handSeq)`.
+- **Display:** On each hand row (e.g. right side): show emoji pills with counts (e.g. `👍 3  🔥 1`). If current user has reacted, show “mine” state (e.g. highlighted/filled).
+- **Actions:** Click emoji to add; click again (or “remove”) to remove. Use a fixed emoji set (e.g. 👍 👏 🔥 😱 ❤️) to avoid abuse.
+- **Optional props on `HandHistory` / `HandHistoryItem`:** e.g. `gameId`, `reactionsByHand`, `onReaction`, `onRemoveReaction` — only passed on the live page so the shared component stays generic.
+
+---
+
+## Polling
+
+- The live page already polls `GET /api/games/[gameId]` (e.g. every 30s) and on visibility/focus. Once reactions are included in that response (or in a parallel reactions endpoint), the same polling pattern will keep reaction counts and “mine” state up to date. No WebSockets required for MVP.
+
+---
+
+## Implementation Order (When Unblocked)
+
+1. **Auth:** Implement user authentication (anonymous or signed-in) so every spectator has a stable `user_id` (or equivalent).
+2. **Schema:** Add migration for `hand_reactions` with unique `(game_id, hand_seq, emoji, user_id)` and indexes.
+3. **API:** Add POST/DELETE for reactions; extend GET game (or add GET reactions) to return reaction counts and “mine” per hand/emoji.
+4. **Live page:** Fetch reactions (with game or separately), pass into `HandHistory`/`HandHistoryItem`, render emoji pills and wire add/remove.
+5. **Rate limiting and polish:** Per-user (and optionally per-IP) limits; fixed emoji set; accessibility (e.g. labels, keyboard).
+
+---
+
+## References
+
+- Live page: `apps/web/src/app/game/[id]/live/page.tsx`
+- Hand history components: `apps/web/src/components/features/game-recording/HandHistory.tsx` (`HandHistory`, `HandHistoryItem`)
+- Hand identity: `(game_id, hand_seq)`; in DB `hand_events` has one row per seat, in UI grouped by `hand_seq`
+- Game API: `apps/web/src/app/api/games/[gameId]/route.ts` (GET returns game + `handEvents`)

--- a/apps/web/src/app/api/games/[gameId]/hands/route.ts
+++ b/apps/web/src/app/api/games/[gameId]/hands/route.ts
@@ -4,6 +4,8 @@ import {
   calculateRonPoints,
   calculateTsumoPoints,
   calculateRonDeltas,
+  calculateMultiRonDeltas,
+  getWinnersByTurnOrderFromLoser,
   calculateTsumoDeltas,
   RIICHI_BET,
   type Seat,
@@ -29,6 +31,8 @@ export interface RecordHandRequest {
   honba: number;
   // For wins (ron/tsumo)
   winnerSeat?: Seat;
+  winnerSeats?: Seat[];
+  winnerHandValues?: Partial<Record<Seat, { han: number; fu: number }>>;
   han?: number;
   fu?: number;
   // For ron specifically
@@ -127,6 +131,17 @@ export async function POST(request: NextRequest, context: RouteContext) {
     const { gameId } = await context.params;
     const supabase = await createClient();
     const body: RecordHandRequest = await request.json();
+    const normalizedWinnerSeats = body.winnerSeats?.length
+      ? body.winnerSeats
+      : body.winnerSeat
+        ? [body.winnerSeat]
+        : [];
+    let resolvedEventType: EventType = body.eventType;
+    let resolvedAbortiveDrawType = body.abortiveDrawType;
+    if (body.eventType === "ron" && normalizedWinnerSeats.length === 3) {
+      resolvedEventType = "abortive_draw";
+      resolvedAbortiveDrawType = "sanchahou";
+    }
 
     // Validate required fields
     if (!body.eventType || !body.round || !body.kyoku || !body.dealerSeat) {
@@ -137,18 +152,38 @@ export async function POST(request: NextRequest, context: RouteContext) {
     }
 
     // Validate win-specific fields
-    if (body.eventType === "ron" || body.eventType === "tsumo") {
-      if (!body.winnerSeat || !body.han || !body.fu) {
+    if (resolvedEventType === "ron" || resolvedEventType === "tsumo") {
+      if (
+        resolvedEventType === "tsumo" &&
+        (!body.winnerSeat || !body.han || !body.fu)
+      ) {
         return NextResponse.json(
           { error: "Winner seat, han, and fu are required for wins" },
           { status: 400 }
         );
       }
-      if (body.eventType === "ron" && !body.loserSeat) {
+      if (resolvedEventType === "ron" && !body.loserSeat) {
         return NextResponse.json(
           { error: "Loser seat is required for ron" },
           { status: 400 }
         );
+      }
+      if (resolvedEventType === "ron") {
+        if (
+          normalizedWinnerSeats.length < 1 ||
+          normalizedWinnerSeats.length > 2
+        ) {
+          return NextResponse.json(
+            { error: "Ron requires 1 or 2 winners" },
+            { status: 400 }
+          );
+        }
+        if (body.loserSeat && normalizedWinnerSeats.includes(body.loserSeat)) {
+          return NextResponse.json(
+            { error: "Loser seat cannot also be a winner" },
+            { status: 400 }
+          );
+        }
       }
     }
 
@@ -183,6 +218,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
     };
     let pointsWon = 0;
     let tier: string | undefined;
+    let riichiCollectorSeat: Seat | undefined;
+    const winnerPoints: Partial<Record<Seat, number>> = {};
 
     const riichiDeclarations = body.riichiDeclarations || [];
     const riichiSticks = body.riichiSticks || 0;
@@ -198,28 +235,74 @@ export async function POST(request: NextRequest, context: RouteContext) {
     // - Plus newly declared riichi sticks from this hand (winner collects all)
     const totalRiichiSticks = riichiSticks + riichiDeclarations.length;
 
-    switch (body.eventType) {
+    switch (resolvedEventType) {
       case "ron": {
-        const isWinnerDealer = body.winnerSeat === body.dealerSeat;
-        const result = calculateRonPoints(
-          body.han!,
-          body.fu!,
-          isWinnerDealer,
-          honba
-        );
-        pointsWon = result.total;
-        tier = result.tier;
+        const winners = normalizedWinnerSeats;
+        if (winners.length === 1) {
+          const winner = winners[0];
+          const values = body.winnerHandValues?.[winner];
+          const winnerHan = values?.han ?? body.han!;
+          const winnerFu = values?.fu ?? body.fu!;
+          const isWinnerDealer = winner === body.dealerSeat;
+          const result = calculateRonPoints(
+            winnerHan,
+            winnerFu,
+            isWinnerDealer,
+            honba
+          );
+          pointsWon = result.total;
+          tier = result.tier;
+          winnerPoints[winner] = result.total;
+          riichiCollectorSeat = winner;
 
-        const ronDeltas = calculateRonDeltas(
-          body.winnerSeat!,
-          body.loserSeat!,
-          result.total,
-          totalRiichiSticks
-        );
+          const ronDeltas = calculateRonDeltas(
+            winner,
+            body.loserSeat!,
+            result.total,
+            totalRiichiSticks
+          );
 
-        // Add ron deltas to existing deltas (from riichi)
-        for (const seat of seats) {
-          deltas[seat] += ronDeltas[seat];
+          // Add ron deltas to existing deltas (from riichi)
+          for (const seat of seats) {
+            deltas[seat] += ronDeltas[seat];
+          }
+        } else {
+          for (const winner of winners) {
+            const values = body.winnerHandValues?.[winner];
+            const winnerHan = values?.han ?? body.han;
+            const winnerFu = values?.fu ?? body.fu;
+            if (!winnerHan || !winnerFu) {
+              return NextResponse.json(
+                { error: "Each ron winner requires han and fu" },
+                { status: 400 }
+              );
+            }
+            const isWinnerDealer = winner === body.dealerSeat;
+            const result = calculateRonPoints(
+              winnerHan,
+              winnerFu,
+              isWinnerDealer,
+              honba
+            );
+            winnerPoints[winner] = result.total;
+            pointsWon += result.total;
+          }
+          const orderedWinners = getWinnersByTurnOrderFromLoser(
+            body.loserSeat!,
+            winners
+          );
+          riichiCollectorSeat = orderedWinners[0] as Seat | undefined;
+          const ronDeltas = calculateMultiRonDeltas(
+            winners,
+            body.loserSeat!,
+            winnerPoints as Record<string, number>,
+            totalRiichiSticks
+          );
+
+          // Add ron deltas to existing deltas (from riichi)
+          for (const seat of seats) {
+            deltas[seat] += ronDeltas[seat];
+          }
         }
         break;
       }
@@ -246,11 +329,18 @@ export async function POST(request: NextRequest, context: RouteContext) {
         for (const seat of seats) {
           deltas[seat] += tsumoDeltas[seat];
         }
+        riichiCollectorSeat = body.winnerSeat;
         break;
       }
 
       case "draw":
       case "abortive_draw": {
+        // Sanchahou (triple ron) is a pure abortive draw: no point exchanges,
+        // no tenpai payments. Only riichi declarations (already applied above) affect scores.
+        if (resolvedAbortiveDrawType === "sanchahou") {
+          break;
+        }
+
         // In a draw, riichi sticks stay on the table
         // The riichi declarations were already subtracted above (lines 192-194)
         // Handle tenpai payments ONLY if not all players are in tenpai
@@ -339,7 +429,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
     // Determine if this is a winning hand where riichi sticks are collected
     const isWinningHand =
-      body.eventType === "ron" || body.eventType === "tsumo";
+      resolvedEventType === "ron" || resolvedEventType === "tsumo";
     const riichiSticksCollected = isWinningHand ? totalRiichiSticks : 0;
 
     // Create hand events for each player
@@ -351,7 +441,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       if (riichiDeclarations.includes(seat)) {
         potDelta -= RIICHI_BET; // Declaring riichi
       }
-      if (seat === body.winnerSeat && riichiSticksCollected > 0) {
+      if (seat === riichiCollectorSeat && riichiSticksCollected > 0) {
         potDelta += riichiSticksCollected * RIICHI_BET; // Collecting riichi sticks
       }
 
@@ -359,7 +449,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         game_id: gameId,
         hand_seq: nextSeq,
         seat,
-        event_type: body.eventType,
+        event_type: resolvedEventType,
         riichi_declared: riichiDeclarations.includes(seat),
         points_delta: deltas[seat],
         pot_delta: potDelta,
@@ -369,14 +459,21 @@ export async function POST(request: NextRequest, context: RouteContext) {
         details: {
           han: body.han,
           fu: body.fu,
+          winnerHandValues: body.winnerHandValues,
+          winnerPoints,
           yakuList: body.yakuList || [],
           dealerSeat: body.dealerSeat,
-          winnerSeat: body.winnerSeat,
+          winnerSeat:
+            normalizedWinnerSeats.length === 1
+              ? normalizedWinnerSeats[0]
+              : undefined,
+          winnerSeats: normalizedWinnerSeats,
           loserSeat: body.loserSeat,
           riichiSticks,
+          riichiCollectorSeat,
           pointsWon,
           tier,
-          abortiveDrawType: body.abortiveDrawType,
+          abortiveDrawType: resolvedAbortiveDrawType,
           tenpaiSeats: body.tenpaiSeats,
         },
       };
@@ -398,7 +495,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       handSeq: nextSeq,
       events: seats.map(seat => ({
         seat,
-        eventType: body.eventType,
+        eventType: resolvedEventType,
         pointsDelta: deltas[seat],
         riichiDeclared: riichiDeclarations.includes(seat),
       })),

--- a/apps/web/src/app/game/[id]/page.tsx
+++ b/apps/web/src/app/game/[id]/page.tsx
@@ -221,13 +221,23 @@ export default function LiveGamePage() {
 
       const isWinningHand =
         lastEvent.event_type === "tsumo" || lastEvent.event_type === "ron";
+      const lastDetails = (lastEvent.details || {}) as {
+        winnerSeat?: Seat;
+        winnerSeats?: Seat[];
+      };
+      const winningSeats = Array.isArray(lastDetails.winnerSeats)
+        ? lastDetails.winnerSeats
+        : lastDetails.winnerSeat
+          ? [lastDetails.winnerSeat]
+          : [];
+      const currentDealerSeat = SEATS[lastEvent.kyoku - 1];
       const dealerEvent = lastHandEvents.find(
-        e => e.seat === SEATS[lastEvent.kyoku - 1]
+        e => e.seat === currentDealerSeat
       );
       const dealerWon: boolean = !!(
         isWinningHand &&
         dealerEvent &&
-        dealerEvent.points_delta > 0
+        winningSeats.includes(currentDealerSeat)
       );
 
       if (lastEvent.event_type === "chombo") {
@@ -411,6 +421,8 @@ export default function LiveGamePage() {
           kyoku,
           honba,
           winnerSeat: data.winnerSeat,
+          winnerSeats: data.winnerSeats,
+          winnerHandValues: data.winnerHandValues,
           loserSeat: data.loserSeat,
           han: data.han,
           fu: data.fu,

--- a/apps/web/src/components/features/game-recording/HandEntryForm.tsx
+++ b/apps/web/src/components/features/game-recording/HandEntryForm.tsx
@@ -19,6 +19,7 @@ import {
   formatPoints,
   getValidFuValues,
   getScoringTier,
+  getWinnersByTurnOrderFromLoser,
   type Seat,
   SEATS,
 } from "@/lib/mahjong";
@@ -42,6 +43,8 @@ export type AbortiveDrawType =
 export interface HandEntryData {
   eventType: EventType;
   winnerSeat?: Seat;
+  winnerSeats?: Seat[];
+  winnerHandValues?: Partial<Record<Seat, { han: number; fu: number }>>;
   loserSeat?: Seat;
   han?: number;
   fu?: number;
@@ -91,8 +94,8 @@ const ABORTIVE_DRAW_TYPES: {
 }[] = [
   { value: "kyuushu_kyuuhai", label: "Nine Terminals", japanese: "九種九牌" },
   { value: "suufon_renda", label: "Four Wind Discards", japanese: "四風連打" },
-  { value: "suucha_riichi", label: "Four Riichi", japanese: "四家立直" },
   { value: "suukan_sanra", label: "Four Kans", japanese: "四槓散了" },
+  { value: "suucha_riichi", label: "Four Riichi", japanese: "四家立直" },
   { value: "sanchahou", label: "Triple Ron", japanese: "三家和" },
 ];
 
@@ -117,6 +120,10 @@ export function HandEntryForm({
 }: HandEntryFormProps) {
   const [eventType, setEventType] = useState<EventType>("ron");
   const [winnerSeat, setWinnerSeat] = useState<Seat | "">("");
+  const [winnerSeats, setWinnerSeats] = useState<Seat[]>([]);
+  const [winnerHandValues, setWinnerHandValues] = useState<
+    Partial<Record<Seat, { han: number; fu: number }>>
+  >({});
   const [loserSeat, setLoserSeat] = useState<Seat | "">("");
   const [han, setHan] = useState<number>(1);
   const [fu, setFu] = useState<number>(30);
@@ -125,29 +132,33 @@ export function HandEntryForm({
     AbortiveDrawType | ""
   >("");
   const [tenpaiSeats, setTenpaiSeats] = useState<Seat[]>([]);
+  const [isAutoAbortive, setIsAutoAbortive] = useState(false);
 
   // Reset form when opened (using useEffect to catch programmatic open changes)
   useEffect(() => {
     if (open) {
       setEventType("ron");
       setWinnerSeat("");
+      setWinnerSeats([]);
+      setWinnerHandValues({});
       setLoserSeat("");
       setHan(1);
       setFu(30);
       setRiichiDeclarations([]);
       setAbortiveDrawType("");
       setTenpaiSeats([]);
+      setIsAutoAbortive(false);
     }
   }, [open]);
 
   // Calculate points preview with detailed breakdown
   const pointsPreview = useMemo(() => {
-    if (!winnerSeat || (eventType !== "ron" && eventType !== "tsumo")) {
+    if (!winnerSeat || eventType !== "tsumo") {
       return null;
     }
 
     const isDealer = winnerSeat === dealerSeat;
-    const isTsumo = eventType === "tsumo";
+    const isTsumo = true;
 
     // Calculate base points (without honba)
     const baseResult = calculatePoints(han, fu, isDealer, isTsumo, 0);
@@ -183,6 +194,61 @@ export function HandEntryForm({
 
   const scoringTier = useMemo(() => getScoringTier(han, fu), [han, fu]);
 
+  const ronPointsPreview = useMemo(() => {
+    if (eventType !== "ron" || winnerSeats.length === 0) {
+      return [];
+    }
+
+    const totalRiichiSticksCollected = riichiSticks + riichiDeclarations.length;
+    const orderedWinners =
+      loserSeat && winnerSeats.length > 0
+        ? getWinnersByTurnOrderFromLoser(loserSeat, winnerSeats)
+        : [];
+    const riichiCollector = orderedWinners[0];
+
+    return winnerSeats.map(seat => {
+      const values = winnerHandValues[seat] || { han: 1, fu: 30 };
+      const isDealer = seat === dealerSeat;
+      const baseResult = calculatePoints(
+        values.han,
+        values.fu,
+        isDealer,
+        false,
+        0
+      );
+      const withHonba = calculatePoints(
+        values.han,
+        values.fu,
+        isDealer,
+        false,
+        honba
+      );
+      const honbaBonus = honba * 300;
+      const getsRiichi = riichiCollector === seat;
+      const riichiValue = getsRiichi ? totalRiichiSticksCollected * 1000 : 0;
+
+      return {
+        seat,
+        han: values.han,
+        fu: values.fu,
+        basePoints: baseResult.total,
+        honbaBonus,
+        riichiValue,
+        riichiSticksCollected: getsRiichi ? totalRiichiSticksCollected : 0,
+        grandTotal: withHonba.total + riichiValue,
+      };
+    });
+  }, [
+    eventType,
+    winnerSeats,
+    winnerHandValues,
+    dealerSeat,
+    honba,
+    riichiSticks,
+    riichiDeclarations.length,
+    loserSeat,
+  ]);
+
   // Auto-convert draw to abortive_draw when 4 players declare riichi
   useEffect(() => {
     const riichiCount = riichiDeclarations.length;
@@ -190,6 +256,7 @@ export function HandEntryForm({
       // 4 riichi = abortive draw (suucha_riichi)
       setEventType("abortive_draw");
       setAbortiveDrawType("suucha_riichi");
+      setIsAutoAbortive(true);
     } else if (
       riichiCount === 4 &&
       eventType === "abortive_draw" &&
@@ -201,8 +268,28 @@ export function HandEntryForm({
       // If user unchecks a riichi and we're at suucha_riichi, clear the type
       // They can select a different abortive draw type or change event type
       setAbortiveDrawType("");
+      setIsAutoAbortive(false);
     }
   }, [riichiDeclarations.length, eventType, abortiveDrawType]);
+
+  // Auto-convert ron to abortive_draw when 3 players win (triple ron)
+  useEffect(() => {
+    const winnerCount = winnerSeats.length;
+    if (winnerCount === 3 && eventType === "ron") {
+      setEventType("abortive_draw");
+      setAbortiveDrawType("sanchahou");
+      setIsAutoAbortive(true);
+    } else if (
+      winnerCount === 3 &&
+      eventType === "abortive_draw" &&
+      !abortiveDrawType
+    ) {
+      setAbortiveDrawType("sanchahou");
+    } else if (winnerCount < 3 && abortiveDrawType === "sanchahou") {
+      setAbortiveDrawType("");
+      setIsAutoAbortive(false);
+    }
+  }, [winnerSeats.length, eventType, abortiveDrawType]);
 
   // When suucha_riichi is selected, ensure exactly 4 riichi are declared
   useEffect(() => {
@@ -242,18 +329,56 @@ export function HandEntryForm({
     return players.find(p => p.seat === seat);
   };
 
+  const toggleRonWinner = (seat: Seat) => {
+    setWinnerSeats(prev => {
+      const isSelected = prev.includes(seat);
+      const next = isSelected ? prev.filter(s => s !== seat) : [...prev, seat];
+      return next;
+    });
+    setWinnerHandValues(prev => {
+      if (prev[seat]) return prev;
+      return { ...prev, [seat]: { han: 1, fu: 30 } };
+    });
+  };
+
+  const updateWinnerHandValue = (
+    seat: Seat,
+    values: Partial<{ han: number; fu: number }>
+  ) => {
+    setWinnerHandValues(prev => {
+      const current = prev[seat] || { han: 1, fu: 30 };
+      return {
+        ...prev,
+        [seat]: {
+          han: values.han ?? current.han,
+          fu: values.fu ?? current.fu,
+        },
+      };
+    });
+  };
+
   const isWinEvent = eventType === "ron" || eventType === "tsumo";
   const needsLoser = eventType === "ron" || eventType === "chombo";
   const isAbortiveDraw = eventType === "abortive_draw";
   const isDraw = eventType === "draw" || eventType === "abortive_draw";
   const hasFourRiichi = riichiDeclarations.length === 4;
+  const hasThreeRonWinners = winnerSeats.length === 3;
   const isSuuchaRiichi = abortiveDrawType === "suucha_riichi";
+  const isSanchahou = abortiveDrawType === "sanchahou";
+  const ronWinnersValid = winnerSeats.every(seat => {
+    const values = winnerHandValues[seat];
+    return !!values && values.han >= 1;
+  });
 
   const canSubmit = () => {
-    if (isWinEvent) {
+    if (eventType === "tsumo") {
       if (!winnerSeat || han < 1) return false;
-      if (eventType === "ron" && !loserSeat) return false;
-      if (eventType === "ron" && winnerSeat === loserSeat) return false;
+    }
+    if (eventType === "ron") {
+      if (winnerSeats.length < 1 || winnerSeats.length > 2) return false;
+      if (!loserSeat) return false;
+      if (winnerSeats.includes(loserSeat as Seat)) return false;
+      if (!ronWinnersValid) return false;
     }
     if (eventType === "chombo" && !loserSeat) return false;
     if (isAbortiveDraw && !abortiveDrawType) return false;
@@ -262,6 +387,15 @@ export function HandEntryForm({
     // If 4 riichi are declared, it must be abortive_draw with suucha_riichi
     if (hasFourRiichi && (eventType !== "abortive_draw" || !isSuuchaRiichi))
       return false;
+    // If sanchahou is selected, exactly 3 ron winners must be retained
+    if (isSanchahou && winnerSeats.length !== 3) return false;
+    // If 3 ron winners are selected, it must be abortive_draw with sanchahou
+    if (
+      hasThreeRonWinners &&
+      (eventType !== "abortive_draw" || abortiveDrawType !== "sanchahou")
+    ) {
+      return false;
+    }
     return true;
   };
 
@@ -273,10 +407,25 @@ export function HandEntryForm({
       riichiDeclarations,
     };
 
-    if (isWinEvent) {
+    if (eventType === "tsumo") {
       data.winnerSeat = winnerSeat as Seat;
       data.han = han;
       data.fu = fu;
+    }
+
+    if (eventType === "ron") {
+      data.winnerSeats = winnerSeats;
+      data.winnerHandValues = winnerHandValues;
+      // Keep backwards compatibility for single-winner consumers
+      if (winnerSeats.length === 1) {
+        const singleWinner = winnerSeats[0];
+        const singleValues = winnerHandValues[singleWinner];
+        if (singleWinner && singleValues) {
+          data.winnerSeat = singleWinner;
+          data.han = singleValues.han;
+          data.fu = singleValues.fu;
+        }
+      }
     }
 
     if (needsLoser && loserSeat) {
@@ -287,12 +436,19 @@ export function HandEntryForm({
       // If 4 riichi are declared, it must be suucha_riichi
       if (hasFourRiichi) {
         data.abortiveDrawType = "suucha_riichi";
+      } else if (hasThreeRonWinners) {
+        data.abortiveDrawType = "sanchahou";
       } else if (abortiveDrawType) {
         data.abortiveDrawType = abortiveDrawType;
       }
+      if (winnerSeats.length > 0) {
+        data.winnerSeats = winnerSeats;
+      }
     }
 
-    if (isDraw && tenpaiSeats.length > 0) {
+    // Sanchahou has no tenpai payments — omit tenpaiSeats so the API doesn't
+    // misinterpret the riichi-populated tenpai list as a noten/tenpai split.
+    if (isDraw && tenpaiSeats.length > 0 && !isSanchahou) {
       data.tenpaiSeats = tenpaiSeats;
     }
 
@@ -335,6 +491,7 @@ export function HandEntryForm({
                     onClick={() => {
                       if (!isDisabled) {
                         setEventType(type.value);
+                        setIsAutoAbortive(false);
                         // If switching away from abortive_draw, clear the type
                         if (type.value !== "abortive_draw") {
                           setAbortiveDrawType("");
@@ -360,17 +517,38 @@ export function HandEntryForm({
           {isAbortiveDraw && (
             <div className="space-y-2">
               <Label>Abortive Draw Type</Label>
-              {isSuuchaRiichi && riichiDeclarations.length !== 4 && (
-                <div className="mb-2 rounded-md border border-red-500/50 bg-red-500/10 p-2 text-sm">
-                  <span className="text-red-700 dark:text-red-400">
-                    ⚠️ Four Riichi (四家立直) requires exactly 4 players to
-                    declare riichi
+              {isSanchahou && isAutoAbortive && (
+                <div className="mb-2 rounded-md border border-blue-500/50 bg-blue-500/10 p-2 text-sm">
+                  <span className="text-blue-700 dark:text-blue-400">
+                    ℹ️ 3 players won by Ron — this is a Triple Ron (三家和) and
+                    counts as an abortive draw
                   </span>
                 </div>
               )}
+              {isSuuchaRiichi && isAutoAbortive && (
+                <div className="mb-2 rounded-md border border-blue-500/50 bg-blue-500/10 p-2 text-sm">
+                  <span className="text-blue-700 dark:text-blue-400">
+                    ℹ️ All 4 players declared riichi — this is a Four Riichi
+                    (四家立直) abortive draw
+                  </span>
+                </div>
+              )}
+              {isSuuchaRiichi &&
+                !isAutoAbortive &&
+                riichiDeclarations.length !== 4 && (
+                  <div className="mb-2 rounded-md border border-red-500/50 bg-red-500/10 p-2 text-sm">
+                    <span className="text-red-700 dark:text-red-400">
+                      ⚠️ Four Riichi (四家立直) requires exactly 4 players to
+                      declare riichi
+                    </span>
+                  </div>
+                )}
               <div className="grid grid-cols-1 gap-2">
-                {ABORTIVE_DRAW_TYPES.map(type => {
+                {ABORTIVE_DRAW_TYPES.filter(
+                  type => !isAutoAbortive || type.value === abortiveDrawType
+                ).map(type => {
                   const isSuuchaRiichiType = type.value === "suucha_riichi";
+                  const isSanchahouType = type.value === "sanchahou";
                   const isSelected = abortiveDrawType === type.value;
                   return (
                     <Button
@@ -378,19 +556,37 @@ export function HandEntryForm({
                       variant={isSelected ? "default" : "outline"}
                       className="flex h-auto min-h-11 items-center justify-start px-4 py-3"
                       onClick={() => {
-                        setAbortiveDrawType(type.value);
-                        // If selecting suucha_riichi, ensure we have 4 riichi
-                        // If deselecting suucha_riichi and we have 4 riichi, we'll auto-set it back
+                        if (isAutoAbortive) return;
+                        if (type.value === "sanchahou") {
+                          // Switch to ron so the user can pick 3 winners; the
+                          // auto-convert effect will switch back to abortive_draw
+                          // with sanchahou once the 3rd winner is selected.
+                          setEventType("ron");
+                          setAbortiveDrawType("");
+                        } else if (type.value === "suucha_riichi") {
+                          // Pre-select all 4 riichi/tenpai declarations so that
+                          // riichiCount is already 4 when React runs the effect,
+                          // preventing the "riichiCount < 4" branch from clearing
+                          // the selection.
+                          setAbortiveDrawType("suucha_riichi");
+                          setRiichiDeclarations([...SEATS]);
+                          setTenpaiSeats([...SEATS]);
+                        } else {
+                          setAbortiveDrawType(type.value);
+                        }
                       }}
                     >
                       <div className="flex flex-col items-start">
                         <span className="font-medium">{type.label}</span>
-                        <span className="text-muted-foreground text-xs">
-                          ({type.japanese})
-                        </span>
-                        {isSuuchaRiichiType && (
-                          <span className="text-muted-foreground mt-1 text-xs italic">
+                        {isSuuchaRiichiType && !isAutoAbortive && (
+                          <span className="mt-1 text-xs text-amber-500 italic">
                             Requires 4 riichi declarations
+                          </span>
+                        )}
+                        {isSanchahouType && !isAutoAbortive && (
+                          <span className="mt-1 text-xs text-amber-500 italic">
+                            Tap to select 3 ron winners — will auto-confirm as
+                            Triple Ron
                           </span>
                         )}
                       </div>
@@ -404,19 +600,27 @@ export function HandEntryForm({
           {/* Winner Selection (for wins) */}
           {isWinEvent && (
             <div className="space-y-2">
-              <Label>Winner</Label>
+              <Label>{eventType === "ron" ? "Winner(s)" : "Winner"}</Label>
               <div className="grid grid-cols-2 gap-2">
                 {SEATS.map(seat => {
                   const player = getPlayerBySeat(seat);
                   if (!player) return null;
                   const isDealer = seat === dealerSeat;
+                  const isSelected =
+                    eventType === "ron"
+                      ? winnerSeats.includes(seat)
+                      : winnerSeat === seat;
 
                   return (
                     <Button
                       key={seat}
-                      variant={winnerSeat === seat ? "default" : "outline"}
+                      variant={isSelected ? "default" : "outline"}
                       className="flex h-11 items-center justify-between gap-2 px-3"
-                      onClick={() => setWinnerSeat(seat)}
+                      onClick={() =>
+                        eventType === "ron"
+                          ? toggleRonWinner(seat)
+                          : setWinnerSeat(seat)
+                      }
                     >
                       <span className="truncate text-sm font-medium">
                         {player.playerName}
@@ -445,7 +649,8 @@ export function HandEntryForm({
                   const player = getPlayerBySeat(seat);
                   if (!player) return null;
                   // Can't deal into yourself - disable instead of hiding
-                  const isDisabled = eventType === "ron" && seat === winnerSeat;
+                  const isDisabled =
+                    eventType === "ron" && winnerSeats.includes(seat);
 
                   return (
                     <Button
@@ -468,13 +673,11 @@ export function HandEntryForm({
             </div>
           )}
 
-          {/* Han/Fu Selection (for wins) */}
-          {isWinEvent && (
+          {/* Han/Fu Selection (for tsumo) */}
+          {eventType === "tsumo" && (
             <Card
               className={cn(
-                !winnerSeat || (eventType === "ron" && !loserSeat)
-                  ? "pointer-events-none opacity-50"
-                  : ""
+                !winnerSeat ? "pointer-events-none opacity-50" : ""
               )}
             >
               <CardHeader className="pb-2">
@@ -485,15 +688,11 @@ export function HandEntryForm({
                   )}
                 </CardTitle>
               </CardHeader>
-              {(!winnerSeat || (eventType === "ron" && !loserSeat)) && (
+              {!winnerSeat && (
                 <div className="px-6 pb-4">
                   <div className="rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm">
                     <span className="text-amber-700 dark:text-amber-400">
-                      {!winnerSeat && eventType === "ron" && !loserSeat
-                        ? "⚠️ Please select Winner and Deal-in first"
-                        : !winnerSeat
-                          ? "⚠️ Please select Winner first"
-                          : "⚠️ Please select Deal-in first"}
+                      ⚠️ Please select Winner first
                     </span>
                   </div>
                 </div>
@@ -606,10 +805,129 @@ export function HandEntryForm({
             </Card>
           )}
 
+          {/* Han/Fu Selection (for ron winners) */}
+          {eventType === "ron" && winnerSeats.length > 0 && (
+            <div className="space-y-4">
+              {winnerSeats.map(seat => {
+                const player = getPlayerBySeat(seat);
+                const values = winnerHandValues[seat] || { han: 1, fu: 30 };
+                const preview = ronPointsPreview.find(p => p.seat === seat);
+                return (
+                  <Card key={seat}>
+                    <CardHeader className="pb-0">
+                      <CardTitle className="text-sm">
+                        Hand Value: {player?.playerName || seat}
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                      <div className="space-y-2">
+                        <Label>Han (翻)</Label>
+                        <div className="flex flex-wrap gap-1.5">
+                          {HAN_OPTIONS.map(option => (
+                            <Button
+                              key={`${seat}-han-${option.value}`}
+                              variant={
+                                values.han === option.value
+                                  ? "default"
+                                  : "outline"
+                              }
+                              size="sm"
+                              className="h-8 min-w-8 px-2"
+                              onClick={() =>
+                                updateWinnerHandValue(seat, {
+                                  han: option.value,
+                                })
+                              }
+                            >
+                              {option.label}
+                            </Button>
+                          ))}
+                        </div>
+                      </div>
+
+                      {values.han < 5 && (
+                        <div className="space-y-2">
+                          <Label>Fu (符)</Label>
+                          <div className="flex flex-wrap gap-1">
+                            {getValidFuValues().map(f => (
+                              <Button
+                                key={`${seat}-fu-${f}`}
+                                variant={
+                                  values.fu === f ? "default" : "outline"
+                                }
+                                size="sm"
+                                className="h-8 w-10 p-0"
+                                onClick={() =>
+                                  updateWinnerHandValue(seat, { fu: f })
+                                }
+                              >
+                                {f}
+                              </Button>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {preview && (
+                        <div className="bg-muted rounded-lg p-4">
+                          <div className="text-muted-foreground mb-2 text-center text-sm">
+                            Ron Points Preview
+                          </div>
+                          <div className="space-y-1 text-sm">
+                            <div className="flex justify-between">
+                              <span className="text-muted-foreground">
+                                Hand value ({preview.han} Han
+                                {preview.han < 5 && `, ${preview.fu} Fu`})
+                              </span>
+                              <span className="text-amber-500">
+                                {formatPoints(preview.basePoints)}
+                              </span>
+                            </div>
+
+                            {preview.honbaBonus > 0 && (
+                              <div className="flex justify-between">
+                                <span className="text-muted-foreground">
+                                  Honba bonus ({honba}本場 × 300)
+                                </span>
+                                <span className="text-foreground">
+                                  +{formatPoints(preview.honbaBonus)}
+                                </span>
+                              </div>
+                            )}
+
+                            {preview.riichiValue > 0 && (
+                              <div className="flex justify-between">
+                                <span className="text-muted-foreground">
+                                  Riichi sticks ({preview.riichiSticksCollected}
+                                  本 × 1,000)
+                                </span>
+                                <span className="text-blue-500">
+                                  +{formatPoints(preview.riichiValue)}
+                                </span>
+                              </div>
+                            )}
+
+                            <div className="border-foreground/20 my-2 border-t" />
+                            <div className="flex items-center justify-between">
+                              <span className="font-medium">Total</span>
+                              <span className="text-2xl font-bold text-green-500">
+                                {formatPoints(preview.grandTotal)}
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+
           {/* Riichi Declarations */}
           <div className="space-y-2">
             <Label>Riichi Declared This Hand</Label>
-            {hasFourRiichi && (
+            {hasFourRiichi && !isAutoAbortive && (
               <div className="mb-2 rounded-md border border-blue-500/50 bg-blue-500/10 p-2 text-sm">
                 <span className="text-blue-700 dark:text-blue-400">
                   ℹ️ All 4 players declared riichi - this is an abortive draw
@@ -651,7 +969,7 @@ export function HandEntryForm({
           </div>
 
           {/* Tenpai Selection (for draws) */}
-          {isDraw && (
+          {isDraw && !isSanchahou && !isAutoAbortive && (
             <div className="space-y-2">
               <Label>Players in Tenpai (聴牌)</Label>
               <div className="grid grid-cols-4 gap-2">

--- a/apps/web/src/components/features/game-recording/HandHistory.tsx
+++ b/apps/web/src/components/features/game-recording/HandHistory.tsx
@@ -21,10 +21,14 @@ export interface HandEvent {
     han?: number;
     fu?: number;
     winnerSeat?: Seat;
+    winnerSeats?: Seat[];
+    winnerHandValues?: Partial<Record<Seat, { han: number; fu: number }>>;
+    winnerPoints?: Partial<Record<Seat, number>>;
     loserSeat?: Seat;
     pointsWon?: number;
     tier?: string;
     riichiSticks?: number; // Sticks on table before this hand
+    riichiCollectorSeat?: Seat;
     tenpaiSeats?: Seat[]; // Players in tenpai for draw hands
     abortiveDrawType?: string; // Type of abortive draw
   };
@@ -135,12 +139,9 @@ export function HandHistoryItem({
     isAbortiveDraw && abortiveDrawType
       ? ABORTIVE_DRAW_TYPE_LABELS[abortiveDrawType]
       : null;
-  const winnerEvent = hand.events.find(e => e.pointsDelta > 0);
-  const winnerEvents = isChombo
+  const winnerEvents = !isDraw
     ? hand.events.filter(e => e.pointsDelta > 0)
-    : winnerEvent
-      ? [winnerEvent]
-      : [];
+    : [];
   const loserEvents = hand.events.filter(e => e.pointsDelta < 0);
   const riichiEvents = hand.events.filter(e => e.riichiDeclared);
 
@@ -157,30 +158,33 @@ export function HandHistoryItem({
       )
     : [];
 
-  // Calculate point breakdown for winning hands
-  const getPointBreakdown = () => {
-    if (!winnerEvent || !hand.details?.pointsWon) return null;
+  const getWinnerBreakdown = (seat: Seat, pointsDelta: number) => {
+    if (isChombo || !hand.details) return null;
 
     const honbaBonus = hand.honba * 300;
-    // Riichi sticks collected = sticks on table + newly declared riichi this hand
-    const existingRiichiSticks = hand.details?.riichiSticks || 0;
+    const existingRiichiSticks = hand.details.riichiSticks || 0;
     const newRiichiSticks = riichiEvents.length;
     const totalRiichiSticks = existingRiichiSticks + newRiichiSticks;
-    const riichiValue = totalRiichiSticks * 1000;
+    const totalRiichiValue = totalRiichiSticks * 1000;
 
-    // Base points = pointsWon (which includes honba) - honba bonus
-    const basePoints = (hand.details?.pointsWon || 0) - honbaBonus;
+    const riichiCollectorSeat =
+      hand.details.riichiCollectorSeat || hand.details.winnerSeat;
+    const riichiValue = seat === riichiCollectorSeat ? totalRiichiValue : 0;
+
+    const winnerPointWithHonba =
+      hand.details.winnerPoints?.[seat] ?? hand.details.pointsWon;
+    if (typeof winnerPointWithHonba !== "number") return null;
+
+    const basePoints = winnerPointWithHonba - honbaBonus;
 
     return {
       basePoints,
       honbaBonus,
       riichiValue,
-      riichiSticksCollected: totalRiichiSticks,
-      grandTotal: winnerEvent.pointsDelta,
+      riichiSticksCollected: riichiValue > 0 ? totalRiichiSticks : 0,
+      grandTotal: pointsDelta,
     };
   };
-
-  const breakdown = getPointBreakdown();
 
   return (
     <div
@@ -238,77 +242,89 @@ export function HandHistoryItem({
       {/* Win details (or chombo recipients) - exclude draws, they use tenpai section */}
       {!isDraw && winnerEvents.length > 0 && hand.details && (
         <div className="mt-2 space-y-1 text-sm">
-          {winnerEvents.map(event => (
-            <div key={event.seat} className="flex items-center gap-2">
-              <div className="flex w-[42px] flex-shrink-0 items-center justify-center">
-                {event.seat === dealerSeat && (
-                  <Badge
-                    variant="outline"
-                    className="border-yellow-500 bg-yellow-500/20 px-2 text-xs"
-                  >
-                    親
-                  </Badge>
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="font-bold text-green-500">
-                  {event.playerName}
-                </span>
-                <span className="text-green-500">
-                  +{formatPoints(event.pointsDelta)}
-                </span>
-                {!isChombo && hand.details?.han && (
-                  <span className="text-muted-foreground text-xs">
-                    {hand.details.han} Han (翻){" "}
-                    {hand.details.fu &&
-                      hand.details.han < 5 &&
-                      `${hand.details.fu} Fu (符)`}
-                  </span>
-                )}
-                {!isChombo && hand.details?.tier && (
-                  <Badge
-                    variant="secondary"
-                    className={cn(
-                      "text-xs",
-                      TIER_CLASSES[hand.details.tier] &&
-                        "!overflow-visible border-0 bg-transparent px-2 py-0"
+          {winnerEvents.map(event => {
+            const breakdown = getWinnerBreakdown(event.seat, event.pointsDelta);
+            return (
+              <div key={event.seat}>
+                <div className="flex items-center gap-2">
+                  <div className="flex w-[42px] flex-shrink-0 items-center justify-center">
+                    {event.seat === dealerSeat && (
+                      <Badge
+                        variant="outline"
+                        className="border-yellow-500 bg-yellow-500/20 px-2 text-xs"
+                      >
+                        親
+                      </Badge>
                     )}
-                  >
-                    <span className={TIER_CLASSES[hand.details.tier] || ""}>
-                      {hand.details.tier}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="font-bold text-green-500">
+                      {event.playerName}
                     </span>
-                  </Badge>
-                )}
-              </div>
-            </div>
-          ))}
-
-          {/* Point breakdown (only for wins, not chombo) */}
-          {!isChombo &&
-            breakdown &&
-            (breakdown.honbaBonus > 0 || breakdown.riichiValue > 0) && (
-              <div className="mt-1.5 flex items-center gap-2">
-                <div className="w-[42px] flex-shrink-0"></div>
-                <div className="bg-muted/50 flex-1 rounded px-0 py-1 text-xs">
-                  <span className="text-amber-500">
-                    + {formatPoints(breakdown.basePoints)} base
-                  </span>
-                  {breakdown.honbaBonus > 0 && (
-                    <span className="text-foreground">
-                      {" "}
-                      + {formatPoints(breakdown.honbaBonus)} honba
+                    <span className="text-green-500">
+                      +{formatPoints(event.pointsDelta)}
                     </span>
-                  )}
-                  {breakdown.riichiValue > 0 && (
-                    <span className="text-blue-500">
-                      {" "}
-                      + {formatPoints(breakdown.riichiValue)} riichi (
-                      {breakdown.riichiSticksCollected}本)
-                    </span>
-                  )}
+                    {!isChombo &&
+                      (hand.details?.han ||
+                        hand.details?.winnerHandValues?.[event.seat]?.han) && (
+                        <span className="text-muted-foreground text-xs">
+                          {(hand.details.winnerHandValues?.[event.seat]?.han ??
+                            hand.details.han) ||
+                            0}{" "}
+                          Han{" "}
+                          {((hand.details.winnerHandValues?.[event.seat]?.han ??
+                            hand.details.han) ||
+                            0) < 5 &&
+                            `${hand.details.winnerHandValues?.[event.seat]?.fu ?? hand.details.fu ?? 30} Fu`}
+                        </span>
+                      )}
+                    {!isChombo && hand.details?.tier && (
+                      <Badge
+                        variant="secondary"
+                        className={cn(
+                          "text-xs",
+                          TIER_CLASSES[hand.details.tier] &&
+                            "!overflow-visible border-0 bg-transparent px-2 py-0"
+                        )}
+                      >
+                        <span className={TIER_CLASSES[hand.details.tier] || ""}>
+                          {hand.details.tier}
+                        </span>
+                      </Badge>
+                    )}
+                  </div>
                 </div>
+
+                {/* Point breakdown (single or multiple ron winners) */}
+                {!isChombo &&
+                  breakdown &&
+                  (hand.eventType === "ron" ||
+                    breakdown.honbaBonus > 0 ||
+                    breakdown.riichiValue > 0) && (
+                    <div className="mt-1.5 flex items-center gap-2">
+                      <div className="w-[42px] flex-shrink-0"></div>
+                      <div className="bg-muted/50 flex-1 rounded px-0 py-1 text-xs">
+                        <span className="text-amber-500">
+                          + {formatPoints(breakdown.basePoints)} base
+                        </span>
+                        {breakdown.honbaBonus > 0 && (
+                          <span className="text-foreground">
+                            {" "}
+                            + {formatPoints(breakdown.honbaBonus)} honba
+                          </span>
+                        )}
+                        {breakdown.riichiValue > 0 && (
+                          <span className="text-blue-500">
+                            {" "}
+                            + {formatPoints(breakdown.riichiValue)} riichi
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  )}
               </div>
-            )}
+            );
+          })}
         </div>
       )}
 
@@ -370,7 +386,7 @@ export function HandHistoryItem({
                         : formatPoints(event.pointsDelta)}
                     </span>
                     <Badge variant="outline" className="text-xs">
-                      Tenpai (聴牌)
+                      Tenpai
                     </Badge>
                   </div>
                 </div>
@@ -381,7 +397,7 @@ export function HandHistoryItem({
                     <div className="w-[42px] flex-shrink-0"></div>
                     <div className="bg-muted/50 flex-1 rounded px-0 py-1 text-xs">
                       <span className="text-green-500">
-                        +{formatPoints(tenpaiPayment)} Tenpai
+                        + {formatPoints(tenpaiPayment)} Tenpai
                       </span>
                       <span className="text-muted-foreground">
                         {" "}

--- a/apps/web/src/features/players/playerStatistics.test.ts
+++ b/apps/web/src/features/players/playerStatistics.test.ts
@@ -142,4 +142,38 @@ describe("calculatePlayerStatistics", () => {
     expect(result.handStats.averageHanOnWins).toBeNull();
     expect(result.handStats.highestHanAchieved).toBeNull();
   });
+
+  it("counts wins from winnerSeats in double ron hands", () => {
+    const result = calculatePlayerStatistics({
+      games: [
+        {
+          gameId: "g1",
+          startedAt: "2026-01-03T00:00:00Z",
+          finishedAt: "2026-01-03T01:00:00Z",
+          seat: "south",
+          finalScore: 29000,
+          placement: 2,
+        },
+      ],
+      handEvents: [
+        {
+          gameId: "g1",
+          handSeq: 1,
+          seat: "south",
+          eventType: "ron",
+          riichiDeclared: false,
+          pointsDelta: 7700,
+          details: {
+            winnerSeats: ["south", "west"],
+            loserSeat: "east",
+            dealerSeat: "north",
+            pointsWon: 7700,
+          },
+        },
+      ],
+    });
+
+    expect(result.totals.totalWins).toBe(1);
+    expect(result.handStats.winRate).toBeCloseTo(100, 5);
+  });
 });

--- a/apps/web/src/features/players/playerStatistics.ts
+++ b/apps/web/src/features/players/playerStatistics.ts
@@ -27,6 +27,7 @@ export interface PlayerHandEventForStats {
   kyoku?: number; // 1-4
   details?: {
     winnerSeat?: Seat;
+    winnerSeats?: Seat[];
     loserSeat?: Seat;
     dealerSeat?: Seat;
     pointsWon?: number;
@@ -191,12 +192,17 @@ export function calculatePlayerStatistics(input: {
   }
   const totalHands = uniqueHands.size;
 
+  const isSeatWinner = (e: PlayerHandEventForStats) => {
+    const winnerSeats = e.details?.winnerSeats;
+    if (Array.isArray(winnerSeats) && winnerSeats.length > 0) {
+      return winnerSeats.includes(e.seat);
+    }
+    return !!e.details?.winnerSeat && e.seat === e.details.winnerSeat;
+  };
+
   // Identify wins and deal-ins using details.{winnerSeat,loserSeat}
   const wins = handEvents.filter(
-    e =>
-      (e.eventType === "tsumo" || e.eventType === "ron") &&
-      e.details?.winnerSeat &&
-      e.seat === e.details.winnerSeat
+    e => (e.eventType === "tsumo" || e.eventType === "ron") && isSeatWinner(e)
   );
 
   const dealIns = handEvents.filter(
@@ -233,19 +239,13 @@ export function calculatePlayerStatistics(input: {
     e => e.details?.dealerSeat && e.seat === e.details.dealerSeat
   );
   const dealerWins = dealerHands.filter(
-    e =>
-      (e.eventType === "tsumo" || e.eventType === "ron") &&
-      e.details?.winnerSeat &&
-      e.seat === e.details.winnerSeat
+    e => (e.eventType === "tsumo" || e.eventType === "ron") && isSeatWinner(e)
   );
   const nonDealerHands = handEvents.filter(
     e => e.details?.dealerSeat && e.seat !== e.details.dealerSeat
   );
   const nonDealerWins = nonDealerHands.filter(
-    e =>
-      (e.eventType === "tsumo" || e.eventType === "ron") &&
-      e.details?.winnerSeat &&
-      e.seat === e.details.winnerSeat
+    e => (e.eventType === "tsumo" || e.eventType === "ron") && isSeatWinner(e)
   );
 
   // Seat-specific hand win rates depend on having game seat assignment data.
@@ -268,11 +268,7 @@ export function calculatePlayerStatistics(input: {
     const seat = seatByGameId.get(e.gameId);
     if (!seat) continue;
     seatHandCounts[seat] += 1;
-    if (
-      (e.eventType === "tsumo" || e.eventType === "ron") &&
-      e.details?.winnerSeat &&
-      e.seat === e.details.winnerSeat
-    ) {
+    if ((e.eventType === "tsumo" || e.eventType === "ron") && isSeatWinner(e)) {
       seatWinCounts[seat] += 1;
     }
   }
@@ -464,8 +460,7 @@ export function calculatePlayerStatistics(input: {
     e =>
       e.riichiDeclared &&
       (e.eventType === "tsumo" || e.eventType === "ron") &&
-      e.details?.winnerSeat &&
-      e.seat === e.details.winnerSeat
+      isSeatWinner(e)
   ).length;
   const noRiichiHandCount = totalHands - riichiHandCount;
   const noRiichiHandWins = wins.length - riichiHandWins;

--- a/apps/web/src/lib/mahjong/points.test.ts
+++ b/apps/web/src/lib/mahjong/points.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateMultiRonDeltas,
+  getWinnersByTurnOrderFromLoser,
+} from "./points";
+
+describe("multi ron helpers", () => {
+  it("orders winners by counter-clockwise turn order from loser", () => {
+    const ordered = getWinnersByTurnOrderFromLoser("east", ["west", "south"]);
+    expect(ordered).toEqual(["south", "west"]);
+  });
+
+  it("applies full loser payment and gives riichi sticks to nearest winner", () => {
+    const deltas = calculateMultiRonDeltas(
+      ["south", "west"],
+      "east",
+      {
+        south: 3900,
+        west: 7700,
+      },
+      2
+    );
+
+    expect(deltas).toEqual({
+      east: -11600,
+      south: 5900,
+      west: 7700,
+      north: 0,
+    });
+  });
+});

--- a/apps/web/src/lib/mahjong/points.ts
+++ b/apps/web/src/lib/mahjong/points.ts
@@ -557,6 +557,59 @@ export function calculateRonDeltas(
 }
 
 /**
+ * Get winners ordered by distance from loser in counter-clockwise turn order.
+ */
+export function getWinnersByTurnOrderFromLoser(
+  loserSeat: string,
+  winnerSeats: string[]
+): string[] {
+  const turnOrder: Record<string, string[]> = {
+    east: ["south", "west", "north"],
+    south: ["west", "north", "east"],
+    west: ["north", "east", "south"],
+    north: ["east", "south", "west"],
+  };
+  const order = turnOrder[loserSeat] || [];
+  return [...winnerSeats].sort((a, b) => order.indexOf(a) - order.indexOf(b));
+}
+
+/**
+ * Calculate deltas for a ron with multiple winners.
+ * The loser pays each winner's full ron value.
+ * Riichi sticks are awarded to the nearest winner by turn order from loser.
+ */
+export function calculateMultiRonDeltas(
+  winnerSeats: string[],
+  loserSeat: string,
+  winnerPoints: Record<string, number>,
+  riichiSticks: number = 0
+): Record<string, number> {
+  const deltas: Record<string, number> = {
+    east: 0,
+    south: 0,
+    west: 0,
+    north: 0,
+  };
+
+  let loserPaymentTotal = 0;
+  for (const winnerSeat of winnerSeats) {
+    const points = winnerPoints[winnerSeat] || 0;
+    deltas[winnerSeat] += points;
+    loserPaymentTotal += points;
+  }
+
+  const orderedWinners = getWinnersByTurnOrderFromLoser(loserSeat, winnerSeats);
+  const riichiRecipient = orderedWinners[0];
+  if (riichiRecipient) {
+    deltas[riichiRecipient] += riichiSticks * 1000;
+  }
+
+  deltas[loserSeat] -= loserPaymentTotal;
+
+  return deltas;
+}
+
+/**
  * Calculate the delta for each player in a tsumo scenario
  *
  * @param winnerSeat - Seat of the winner

--- a/docs/specs/hand-recording-feature.md
+++ b/docs/specs/hand-recording-feature.md
@@ -643,6 +643,28 @@ DELETE /api/games/{gameId}/hands/{handId}
 6. **Draw Validation**: Tenpai payments must balance
 7. **Bankruptcy Handling**: When tobi is enabled, validate game end conditions
 
+### Multi-Ron Rule Clarification
+
+The hand recorder must treat multi-ron outcomes using the following league rules:
+
+1. **Double Ron (2 winners)**
+   - Each winner's hand is scored independently (separate han/fu inputs).
+   - The discarder pays the full ron value to each winner.
+   - Honba is not split: the discarder pays full honba bonus (`300 x honba`) to each winner.
+   - Riichi sticks are awarded to exactly one winner: the winning player nearest to the discarder in turn order (counter-clockwise from discarder), even if that player did not declare riichi.
+   - Dealer repeats only if dealer is one of the winning players; otherwise dealership passes.
+
+2. **Triple Ron (3 winners)**
+   - Triple ron is treated as an abortive draw (`sanchahou`).
+   - No ron hand payouts are exchanged.
+   - Riichi sticks remain on the table.
+   - Honba increases by `+1`.
+   - Dealer repeats (draw treatment).
+
+3. **Input behavior requirement**
+   - If `ron` reaches 3 selected winners in the hand entry UI, the flow must auto-convert to `abortive_draw` with `sanchahou` preselected.
+   - The 3 selected winners should be retained in details for historical context.
+
 ### Handling Incomplete/Uncertain Data
 
 The system supports recording hands with incomplete information:


### PR DESCRIPTION
- Add support for double ron and triple ron scenarios, including scoring and point distribution.
- Update API to accept multiple winners and validate winner inputs.
- Enhance UI to auto-convert to abortive draw when three winners are selected.
- Update documentation to clarify multi-ron rules and input behavior requirements.